### PR TITLE
install typescript before aws-cdk installation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ function parseInputs(){
 }
 
 function installTypescript(){
-	npm install -g typescript
+	npm install typescript
 }
 
 function installAwsCdk(){

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,10 @@ function parseInputs(){
 	fi
 }
 
+function installTypescript(){
+	npm install -g typescript
+}
+
 function installAwsCdk(){
 	echo "Install aws-cdk ${INPUT_CDK_VERSION}"
 	if [ "${INPUT_CDK_VERSION}" == "latest" ]; then
@@ -75,6 +79,7 @@ ${output}
 function main(){
 	parseInputs
 	cd ${GITHUB_WORKSPACE}/${INPUT_WORKING_DIR}
+	installTypescript
 	installAwsCdk
 	installPipRequirements
 	runCdk


### PR DESCRIPTION
This PR adds ``typescript`` package required to run ``aws-cdk`` properly. 
Typescript is installed locally, according to https://github.com/TypeStrong/ts-node/issues/707#issuecomment-457448149.


Also fixes #9.