### PR TITLE
Add git to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3
 
-RUN apk --update --no-cache add nodejs nodejs-npm python3 py3-pip jq curl bash && \
+RUN apk --update --no-cache add nodejs nodejs-npm python3 py3-pip jq curl bash git && \
 	ln -sf /usr/bin/python3 /usr/bin/python
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Added Git to Dockerfile to allow python requirements.txt to install dependencies from git repositories (e.g. local or private packages)

This is in response to issue [#11 ](https://github.com/youyo/aws-cdk-github-actions/issues/11)