### PR TITLE
Added docker to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3
 
-RUN apk --update --no-cache add nodejs nodejs-npm python3 py3-pip jq curl bash git && \
+RUN apk --update --no-cache add nodejs nodejs-npm python3 py3-pip jq curl bash git docker && \
 	ln -sf /usr/bin/python3 /usr/bin/python
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Docker is needed in the container if you are trying to deploy something to fargate in cdk, since cdk builds and pushes the docker container for you.