### PR TITLE
Fix AWS CDK arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
           cdk_subcommand: 'deploy'
           cdk_stack: 'stack1'
           actions_comment: false
-          args: '--require-approval never'
+          cdk_args: '--require-approval never'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -86,6 +86,7 @@ jobs:
 - `cdk_subcommand` **Required** AWS CDK subcommand to execute.
 - `cdk_version` AWS CDK version to install. (default: 'latest')
 - `cdk_stack` AWS CDK stack name to execute. (default: '*')
+- `cdk_args` AWS CDK CLI arguments (default: '')
 - `working_dir` AWS CDK working directory. (default: '.')
 - `actions_comment` Whether or not to comment on pull requests. (default: true)
 - `debug_log` Enable debug-log. (default: false)

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   cdk_subcommand:
     description: 'AWS CDK subcommand to execute.'
     required: true
+  cdk_args:
+    description: 'AWS CDK CLI arguments'
+    default: ''
   working_dir:
     description: 'AWS CDK working directory.'
     default: '.'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,8 +61,8 @@ function installPipRequirements(){
 }
 
 function runCdk(){
-	echo "Run cdk ${INPUT_CDK_SUBCOMMAND} ${*} \"${INPUT_CDK_STACK}\""
-	output=$(cdk ${INPUT_CDK_SUBCOMMAND} ${*} "${INPUT_CDK_STACK}" 2>&1)
+	echo "Run cdk ${INPUT_CDK_SUBCOMMAND} ${*} \"${INPUT_CDK_STACK}\" ${INPUT_CDK_ARGS}"
+	output=$(cdk ${INPUT_CDK_SUBCOMMAND} ${*} "${INPUT_CDK_STACK} ${INPUT_CDK_ARGS}" 2>&1)
 	exitCode=${?}
 	echo ::set-output name=status_code::${exitCode}
 	echo "${output}"


### PR DESCRIPTION
This change modifies the GitHub action to add an additional parameter of cdk_args, more closely matching the README example. It is also possible to pass these in as cdk_subdommand so I am not sure what is preferred.

If including it as part of cdk_subcommand I can create a PR to clarify the README.