### PR TITLE
Added support for gcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3
 
-RUN apk --update --no-cache add nodejs nodejs-npm python3 py3-pip jq curl bash git docker && \
+RUN apk --update --no-cache add nodejs nodejs-npm python3 py3-pip jq curl bash git docker build-base && \
 	ln -sf /usr/bin/python3 /usr/bin/python
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Some python dependencies rely on gcc for installation, this means that `apk add build-base` needs to be installed on the container, as alpine is not shipped with build-base or gcc.