### PR TITLE
Removing unnecessary npm install output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ function parseInputs(){
 }
 
 function installTypescript(){
-	npm install typescript
+	npm install --no-fund --no-audit --log-level=error typescript
 }
 
 function installAwsCdk(){


### PR DESCRIPTION
Every action run contains npm output that doesn't add any value. By adding flags to the `npm install` we can remove the following lines of output:

~npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@2.1.3 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.1.3: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})~

+ typescript@3.7.5
added 796 packages from 467 contributors and audited 802 packages in 16.264s

~15 packages are looking for funding
  run `npm fund` for details~

~found 2 high severity vulnerabilities
  run `npm audit fix` to fix them, or `npm audit` for details~
Install aws-cdk latest