### PR TITLE
fail action if cdk subcommand exits with non-zero exit code

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,8 +68,11 @@ function runCdk(){
 	echo "${output}"
 
 	commentStatus="Failed"
-	if [ "${exitCode}" == "0" -o "${exitCode}" == "1" ]; then
+	if [ "${exitCode}" == "0" ]; then
 		commentStatus="Success"
+	elif [ "${exitCode}" != "0" ]; then
+		echo "CDK subcommand ${INPUT_CDK_SUBCOMMAND} for stack ${INPUT_CDK_STACK} has failed. See above console output for more details."
+		exit 1
 	fi
 
 	if [ "$GITHUB_EVENT_NAME" == "pull_request" ] && [ "${INPUT_ACTIONS_COMMENT}" == "true" ]; then


### PR DESCRIPTION
A little bit of background on why I want this action to cause failures in workflows:

When I was initially setting up my own GitHub workflows using this action to deploy an AWS lambda via the CDK, the IAM user I had built in AWS was lacking some of the needed permissions to successfully deploy my app. I could see in my workflow which permissions I was missing, but noticed that the workflow itself was still passing, even though my lambda was ultimately not being deployed. 

This change will cause any failure in the cdk subcommands to fail the workflow and make that feedback easier to see for users.

P.S. this link is in the issue related to this PR (referenced in first comment by myself) but here is a link to the pull request that made the cdk diff functionality that initially lead to not failing on an exit code of 1 change: https://github.com/aws/aws-cdk/commit/4f765b2657ceae4a18c6cc62fe99393a03221a87
