### PR TITLE
updated npm pkg from outdated nodejs-npm to npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3
 
-RUN apk --update --no-cache add nodejs nodejs-npm python3 py3-pip jq curl bash git docker && \
+RUN apk --update --no-cache add nodejs npm python3 py3-pip jq curl bash git docker && \
 	ln -sf /usr/bin/python3 /usr/bin/python
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
The current version is not building correctly cause it's using a deprecated package name for npm  for more details see #34 