### PR TITLE
Upgrade to alpine 3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.14
 
 RUN apk --update --no-cache add nodejs npm python3 py3-pip jq curl bash git docker && \
 	ln -sf /usr/bin/python3 /usr/bin/python

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,6 +61,13 @@ function installPipRequirements(){
 }
 
 function runCdk(){
+  user=$(stat -c "%u" node_modules)
+  group=$(stat -c "%g" node_modules)
+  addgroup -g $group github
+  adduser -u $user -G github -D github
+  mkdir -p cdk.out
+  chown github:github cdk.out
+
 	echo "Run cdk ${INPUT_CDK_SUBCOMMAND} ${*} \"${INPUT_CDK_STACK}\""
 	set -o pipefail
 	cdk ${INPUT_CDK_SUBCOMMAND} ${*} "${INPUT_CDK_STACK}" 2>&1 | tee output.log


### PR DESCRIPTION
This is super hacky, but I couldn't find a better way around this.  For some reason when cdk runs it's running as the user 1001 and group 121, but the "cdk.out" folder gets created as root, which cdk doesn't have permissions to write to.  This pre-creates the cdk.out directory and changes the owner of it to 1001 so that cdk can write to it.

I wasn't sure if 1001:121 was static or not, and I couldn't find a way to get it from github, so this figures out the user and group id from the `node_modules` folder and creates a user and group with those ids.

The other thing I want to try is having Docker run as a different user besides root, but thought I'd share this hacky solution in the meantime.