### PR TITLE
Deploying multiple Stacks 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,7 +63,7 @@ function installPipRequirements(){
 function runCdk(){
 	echo "Run cdk ${INPUT_CDK_SUBCOMMAND} ${*} \"${INPUT_CDK_STACK}\""
 	set -o pipefail
-	cdk ${INPUT_CDK_SUBCOMMAND} ${*} "${INPUT_CDK_STACK}" 2>&1 | tee output.log
+	cdk ${INPUT_CDK_SUBCOMMAND} ${*} ${INPUT_CDK_STACK} 2>&1 | tee output.log
 	exitCode=${?}
 	set +o pipefail
 	echo ::set-output name=status_code::${exitCode}


### PR DESCRIPTION
I would like to deploy multiple Stacks. cdk deploy allows to you do that . like
`cdk deploy TestStack Test2Stack` 

so by removing the double quotes should fix it. Didn't tested though. 

So when I put multiple stacks on input.cdk_stack, it should work. 

