### PR TITLE
Updates alpine version to v3.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.17
 
 RUN apk --update --no-cache add nodejs npm python3 py3-pip jq curl bash git docker && \
 	ln -sf /usr/bin/python3 /usr/bin/python


### PR DESCRIPTION
* It is done in order to get node v18
* At the moment alpine v3.13 is having node v14 which is supposed to be EOL in a few days.
* not going for alpine edge repo because it may have unforeseen result if base image is quite old

```
Run cdk synth "*"
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!                                                                                                        !!
!!  Node 14 is approaching end-of-life and will no longer be supported in new releases after 2023-04-30.  !!
!!  Please upgrade to a supported node version as soon as possible.                                       !!
!!                                                                                                        !!
!!  This software is currently running on node v14.20.1.                                                  !!
!!  As of the current release of this software, supported node releases are:                              !!
!!  - ^18.0.0 (Planned end-of-life: 2025-04-30)                                                           !!
!!  - ^16.3.0 (Planned end-of-life: 2023-09-11)                                                           !!
!!  - ^14.6.0 (Planned end-of-life: 2023-04-30) [DEPRECATED]                                              !!
!!                                                                                                        !!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
b'!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n'
b'!!                                                                                                                  !!\n'
b'!!  Node 14 is approaching end-of-life and will no longer be supported in new releases after 2023-04-30.            !!\n'
b'!!  Please upgrade to a supported node version as soon as possible.                                                 !!\n'
b'!!                                                                                                                  !!\n'
b'!!  This software is currently running on node v14.20.1.                                                            !!\n'
b'!!  As of the current release of this software, supported node releases are:                                        !!\n'
b'!!  - ^18.0.0 (Planned end-of-life: 2025-04-30)                                                                     !!\n'
b'!!  - ^16.3.0 (Planned end-of-life: 2023-09-11)                                                                     !!\n'
b'!!  - ^19.0.0 (Planned end-of-life: 2023-06-01)                                                                     !!\n'
b'!!  - ^14.6.0 (Planned end-of-life: 2023-04-30) [DEPRECATED]                                                        !!\n'
b'!!                                                                                                                  !!\n'
b'!!  This warning can be silenced by setting the JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION environment variable.  !!\n'
b'!!                                                                                                                  !!\n'
b'!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n'
```


verfied by building the relevant docker image that node v18 is present
```
❯ docker run -it --rm --entrypoint "" aws-cdk-github-actions:latest sh -c "node -v"
v18.14.2
```